### PR TITLE
Discard radar data after 30 seconds, grey out after 10 seconds

### DIFF
--- a/source/Drawables.mc
+++ b/source/Drawables.mc
@@ -31,9 +31,9 @@ class Background extends WatchUi.Drawable {
 }
 
 /*  *************************************************************
-    Combined compass and radar speed indicator   
+    Combined compass and radar speed indicator
     *************************************************************   */
-class RadarCompass extends WatchUi.Drawable {  
+class RadarCompass extends WatchUi.Drawable {
     private var _fontCompIcon;      // compass icons font
     private var _fontSpeedNumber;   // wehicle speed number font
     private var _align;             // device related text align class
@@ -130,13 +130,16 @@ class RadarCompass extends WatchUi.Drawable {
         dc.setColor(Graphics.COLOR_WHITE, Graphics.COLOR_WHITE);
         dc.fillCircle(locX+17, locY+30, baseRadarRadius);
         if (sensors[:carDanger] == 1) {
-            dc.setColor(Graphics.COLOR_GREEN, Graphics.COLOR_WHITE);    
+            dc.setColor(Graphics.COLOR_GREEN, Graphics.COLOR_WHITE);
         } else if (sensors[:carDanger] == 2) {
-            dc.setColor(Graphics.COLOR_YELLOW, Graphics.COLOR_WHITE);    
-        } else {
+            dc.setColor(Graphics.COLOR_YELLOW, Graphics.COLOR_WHITE);
+        } else if (sensors[:carDanger] == 3) {
             dc.setColor(Graphics.COLOR_RED, Graphics.COLOR_WHITE);
+        } else { //unknown or outdated
+            dc.setColor(Graphics.COLOR_LT_GRAY, Graphics.COLOR_WHITE);
         }
-        dc.setPenWidth(8);        
+
+        dc.setPenWidth(8);
         dc.drawCircle(locX+17, locY+30, baseRadarRadius);
         dc.setColor(Graphics.COLOR_BLACK, Graphics.COLOR_TRANSPARENT);
         dc.drawText(locX + 17, locY+18, _fontSpeedNumber, sensors[:carSpeed].format("%u"), Graphics.TEXT_JUSTIFY_CENTER);
@@ -176,7 +179,7 @@ class RadarCompass extends WatchUi.Drawable {
         dc.drawText(locX + 19, locY-_labelOffset, Graphics.FONT_MEDIUM, label, Graphics.TEXT_JUSTIFY_CENTER);
         dc.setColor(Graphics.COLOR_RED, Graphics.COLOR_TRANSPARENT);
         dc.drawText(locX+19, locY+baseCompassRadius, _fontCompIcon, getDirection(sensors[:heading]).format("%1u"), Graphics.TEXT_JUSTIFY_CENTER);
-    }    
+    }
 }
 
 
@@ -198,7 +201,7 @@ class HRZoneBar extends WatchUi.Drawable {
         _hrZones = UserProfile.getHeartRateZones(UserProfile.getCurrentSport());
         if (_hrZones.size() != 6 ) {
             _hrZones = [1,2,3,4,5,6];
-        }        
+        }
         // _hrPixel =  90 / (_hrZones[5]-_hrZones[0]).toFloat();
         _hrPixel =  75 / (_hrZones[5]-_hrZones[2]).toFloat();
         _imgVRainbowBar = Application.loadResource( Rez.Drawables.imageVRainbowBar ) as BitmapResource;
@@ -217,7 +220,7 @@ class HRZoneBar extends WatchUi.Drawable {
 
     /*  *************************************************************
     */
-    function getZone(_hr) as Number {        
+    function getZone(_hr) as Number {
         for (var f=0; f<=4; f++) {
             if ((_hr>=_hrZones[f]) && (_hr<=_hrZones[f+1])) {
                 return f;
@@ -240,14 +243,14 @@ class HRZoneBar extends WatchUi.Drawable {
         if (_hr > _hrZones[5]) {
             _hr = _hrZones[5];
         } else if (_hr < _hrZones[2]) {
-            _hr = _hrZones[2];               
+            _hr = _hrZones[2];
         }
 
         var ZoneClear = [2,2,2,1,0,0];
         dc.setColor(bgColor, Graphics.COLOR_TRANSPARENT);
         dc.drawBitmap(locX, locY+23, _imgVRainbowBar);
-        // dc.fillRectangle(locX, locY+23, 15, Math.floor(_hrPixel * (_hrZones[5] - hr) ));        
-        dc.fillRectangle(locX, locY+23, 15, Math.floor(ZoneClear[getZone(_hr)]*25));        
+        // dc.fillRectangle(locX, locY+23, 15, Math.floor(_hrPixel * (_hrZones[5] - hr) ));
+        dc.fillRectangle(locX, locY+23, 15, Math.floor(ZoneClear[getZone(_hr)]*25));
 
         var y = Math.floor(_hrPixel * (_hrZones[5] - _hr) );
         if (y>70) {


### PR DESCRIPTION
I noticed a small bug that when you switch off your varia radar while there's an active alert it would keep displaying the car speed indefinitely. I often switch it off when I move from public roads to gravel/bike lanes to avoid nonsense alerts. I made a fix for that to first gray out the car speed after 10 seconds and then discard after 30.

There is also some trailing whitespace cleanup done by VSCode.